### PR TITLE
Disable unified search by default

### DIFF
--- a/lib/Search/VideoSearchProvider.php
+++ b/lib/Search/VideoSearchProvider.php
@@ -88,7 +88,7 @@ class VideoSearchProvider implements IProvider {
 		$requestedFromSmartPicker = $routeFrom === '' || $routeFrom === 'smart-picker';
 
 		if (!$requestedFromSmartPicker) {
-			$searchEnabled = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'search_enabled', '1') === '1';
+			$searchEnabled = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'search_enabled', '0') === '1';
 			if (!$searchEnabled) {
 				return SearchResult::paginated($this->getName(), [], 0);
 			}

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -19,7 +19,7 @@ class Personal implements ISettings {
 	 * @return TemplateResponse
 	 */
 	public function getForm(): TemplateResponse {
-		$searchEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'search_enabled', '1') === '1';
+		$searchEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'search_enabled', '0') === '1';
 		$linkPreviewEnabled = $this->config->getUserValue($this->userId, Application::APP_ID, 'link_preview_enabled', '1') === '1';
 
 		$userConfig = [


### PR DESCRIPTION
closes #10 

There only is a user-specific setting to toggle the unified search provider. It is now disabled by default.

This setting has no impact on the smart picker search.