### PR TITLE
Prepare release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## 1.1.0 – 2025-01-09
+## 1.3.0 – 2025-08-29
+
+### Added
+- search providers marked as external sources 
+
+### Changed
+- npm packages updated 
+- max NC version bumped to 32
+- CSP Nonce updated
+
+## 1.2.0 – 2025-01-09
 
 Maintenance update. Add NC31 support.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
     <summary>Integration of PeerTube decentralized and federated video platform</summary>
     <description><![CDATA[PeerTube integration provides a smart picker provider to search for videos
 and a link preview widget for video links.]]></description>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Peertube</namespace>


### PR DESCRIPTION
### Added
- search providers marked as external sources 

### Changed
- npm packages updated 
- max NC version bumped to 32
- CSP Nonce updated