### PR TITLE
Prepare 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## 1.3.1 – 2025-09-01
+
+### Changed
+
+- Do not use IExternalProvider anymore
+- Lower max NC version to 31
 
 ## 1.3.0 – 2025-08-29
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
     <summary>Integration of PeerTube decentralized and federated video platform</summary>
     <description><![CDATA[PeerTube integration provides a smart picker provider to search for videos
 and a link preview widget for video links.]]></description>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Peertube</namespace>
@@ -24,7 +24,7 @@ and a link preview widget for video links.]]></description>
     <screenshot>https://github.com/julien-nc/integration_peertube/raw/main/img/screenshot3.jpg</screenshot>
     <screenshot>https://github.com/julien-nc/integration_peertube/raw/main/img/screenshot4.jpg</screenshot>
     <dependencies>
-        <nextcloud min-version="28" max-version="32"/>
+        <nextcloud min-version="28" max-version="31"/>
     </dependencies>
     <settings>
         <admin>OCA\Peertube\Settings\Admin</admin>


### PR DESCRIPTION
### Changed

- Do not use IExternalProvider anymore
- Lower max NC version to 31