### PR TITLE
2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.0 – 2025-10-06
+
+### Added
+- migrate to vue3 (#30) @kyteinsky
+- lighter non-interactive reference widget by default (#33) @kyteinsky @julien-nc
+
+### Changed
+- use lazy admin config values (#31) @kyteinsky
+- composer update and bump max NC version to 33 (#33) @kyteinsky
+
+
 ## 2.0.0 – 2025-09-01
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
     <summary>Integration of PeerTube decentralized and federated video platform</summary>
     <description><![CDATA[PeerTube integration provides a smart picker provider to search for videos
 and a link preview widget for video links.]]></description>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <namespace>Peertube</namespace>


### PR DESCRIPTION
## 2.1.0 – 2025-10-06

### Added
- migrate to vue3 (#30) @kyteinsky
- lighter non-interactive reference widget by default (#33) @kyteinsky @julien-nc

### Changed
- use lazy admin config values (#31) @kyteinsky
- composer update and bump max NC version to 33 (#33) @kyteinsky
