### PR TITLE
chore(bundle): import from @nextcloud/vue/functions/registerReference

### DIFF
--- a/src/reference.js
+++ b/src/reference.js
@@ -5,7 +5,7 @@
 
 import { getCSPNonce } from '@nextcloud/auth'
 import { linkTo } from '@nextcloud/router'
-import { registerWidget } from '@nextcloud/vue/components/NcRichText'
+import { registerWidget } from '@nextcloud/vue/functions/registerReference'
 
 __webpack_nonce__ = getCSPNonce() // eslint-disable-line
 __webpack_public_path__ = linkTo('integration_peertube', 'js/') // eslint-disable-line


### PR DESCRIPTION
This reduces the references asset from > 800k to < 50k.
